### PR TITLE
Patch type definitions for TypeScript ^2.7.1

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,10 +6,10 @@ import axios, {
   CancelTokenStatic
 } from 'axios'
 
-import {RestypedBase, RestypedRoute} from 'restyped'
+import {RestypedBase, RestypedIndexedBase, RestypedRoute} from 'restyped'
 
 export interface TypedAxiosRequestConfig<
-  API extends RestypedBase,
+  API extends RestypedIndexedBase,
   Path extends keyof API,
   Method extends keyof API[Path],
   RouteDef extends RestypedRoute = API[Path][Method]
@@ -21,7 +21,7 @@ export interface TypedAxiosRequestConfig<
 }
 
 export interface TypedAxiosResponse<
-  API extends RestypedBase,
+  API extends RestypedIndexedBase,
   Path extends keyof API,
   Method extends keyof API[Path],
   RouteDef extends RestypedRoute = API[Path][Method]


### PR DESCRIPTION
Fixes #3.

Note: there are probably more issues that should be addressed, though. For example:

```ts
post<Path extends keyof API>(
  url: Path | string,
  data?: API[Path]['POST']['Request'], // Allowed values are ('params' | 'query' | 'body' | 'response')
  config?: TypedAxiosRequestConfig<API, Path, 'POST'>
): Promise<TypedAxiosResponse<API, Path, 'POST'>>
```

The `'Request'` string literal cannot be used to index `RestypedRoute`.

```ts
export interface RestypedRoute {
  params: any
  query: any
  body: any
  response: any
}
```

But I guess it's a topic for another PR. ;-)