### PR TITLE
Upgrade to TypeScript 2.9, and fix index.ts types using Extract

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,19 +10,19 @@ import {RestypedBase, RestypedIndexedBase, RestypedRoute} from 'restyped'
 
 export interface TypedAxiosRequestConfig<
   API extends RestypedIndexedBase,
-  Path extends keyof API,
+  Path extends Extract<keyof API, string>,
   Method extends keyof API[Path],
   RouteDef extends RestypedRoute = API[Path][Method]
 > extends AxiosRequestConfig {
   url?: Path
-  method?: Method
+  method?: Extract<Method, string>
   params?: RouteDef['query']
   data?: RouteDef['body']
 }
 
 export interface TypedAxiosResponse<
   API extends RestypedIndexedBase,
-  Path extends keyof API,
+  Path extends Extract<keyof API, string>,
   Method extends keyof API[Path],
   RouteDef extends RestypedRoute = API[Path][Method]
 > extends AxiosResponse {
@@ -32,38 +32,38 @@ export interface TypedAxiosResponse<
 
 export interface TypedAxiosInstance<API extends RestypedBase = any>
   extends AxiosInstance {
-  request<Path extends keyof API, Method extends keyof API[Path] = 'GET'>(
+  request<Path extends Extract<keyof API, string>, Method extends keyof API[Path] = 'GET'>(
     config: TypedAxiosRequestConfig<API, Path, Method>
   ): Promise<TypedAxiosResponse<API, Path, Method>>
 
-  get<Path extends keyof API>(
+  get<Path extends Extract<keyof API, string>>(
     url: Path | string,
     config?: TypedAxiosRequestConfig<API, Path, 'GET'>
   ): Promise<TypedAxiosResponse<API, Path, 'GET'>>
 
-  delete<Path extends keyof API>(
+  delete<Path extends Extract<keyof API, string>>(
     url: Path | string,
     config?: TypedAxiosRequestConfig<API, Path, 'DELETE'>
   ): Promise<TypedAxiosResponse<API, Path, 'DELETE'>>
 
-  head<Path extends keyof API>(
+  head<Path extends Extract<keyof API, string>>(
     url: Path | string,
     config?: TypedAxiosRequestConfig<API, Path, 'HEAD'>
   ): Promise<TypedAxiosResponse<API, Path, 'HEAD'>>
 
-  post<Path extends keyof API>(
+  post<Path extends Extract<keyof API, string>>(
     url: Path | string,
     data?: API[Path]['POST']['body'],
     config?: TypedAxiosRequestConfig<API, Path, 'POST'>
   ): Promise<TypedAxiosResponse<API, Path, 'POST'>>
 
-  put<Path extends keyof API>(
+  put<Path extends Extract<keyof API, string>>(
     url: Path | string,
     data?: API[Path]['PUT']['body'],
     config?: TypedAxiosRequestConfig<API, Path, 'PUT'>
   ): Promise<TypedAxiosResponse<API, Path, 'PUT'>>
 
-  patch<Path extends keyof API>(
+  patch<Path extends Extract<keyof API, string>>(
     url: Path | string,
     data?: API[Path]['PATCH']['body'],
     config?: TypedAxiosRequestConfig<API, Path, 'PATCH'>
@@ -72,11 +72,11 @@ export interface TypedAxiosInstance<API extends RestypedBase = any>
 
 export interface TypedAxiosStatic<API extends RestypedBase = any>
   extends TypedAxiosInstance<API> {
-  <Path extends keyof API, Method extends keyof API[Path] = 'GET'>(
+  <Path extends Extract<keyof API, string>, Method extends keyof API[Path] = 'GET'>(
     config: TypedAxiosRequestConfig<API, Path, Method>
   ): Promise<TypedAxiosResponse<API, Path, Method>>
 
-  <Path extends keyof API, Method extends keyof API[Path]>(
+  <Path extends Extract<keyof API, string>, Method extends keyof API[Path]>(
     url: Path | string,
     config?: TypedAxiosRequestConfig<API, Path, Method>
   ): Promise<TypedAxiosResponse<API, Path, Method>>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
       "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "requires": {
-        "follow-redirects": "1.2.5",
-        "is-buffer": "1.1.5"
+        "follow-redirects": "^1.2.3",
+        "is-buffer": "^1.1.5"
       }
     },
     "debug": {
@@ -26,7 +26,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
       "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.6.9"
       }
     },
     "is-buffer": {
@@ -45,9 +45,9 @@
       "integrity": "sha512-Q5rxwCnw0AR4/8I7YOxE0/ElyHcB86UtV4U0RnyxXY/s8EDwd1AZGTXxrKQUAdVbPljlNsz4VXXq6oT5HnnxPw=="
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w=="
+      "version": "2.9.2",
+      "resolved": "https://nexus.q-internal.tech/repository/npm-group/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "axios": "^0.16.2",
     "restyped": "1.1.0",
-    "typescript": "^2.4.0"
+    "typescript": "^2.9.2"
   }
 }


### PR DESCRIPTION
Similar to the changes in https://github.com/rawrmaan/restyped-axios/pull/8, but utilizes the `Extract` keyword like recommended