### PR TITLE
Allow usage of path params using generic request

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ export interface TypedAxiosRequestConfig<
   Method extends keyof API[Path],
   RouteDef extends RestypedRoute = API[Path][Method]
 > extends AxiosRequestConfig {
-  url?: Path
+  url?: Path | string
   method?: Extract<Method, string>
   params?: RouteDef['query']
   data?: RouteDef['body']


### PR DESCRIPTION
This will allow providing a URL with params provided for a path like '/ex/:id/name' using the generic request method rather than using .put .get etc...

In this way the request can be done as follows:
```
const id = "123";
client.request<'/ex/:id/name', 'GET'>({ url: '/ex/${id}/name'}); // this rather than
client.get<'/ex/:id/name'>('/ex/${id}/name', {...}); // this
```

Being forced to use .get .post and others to allow for path params is more work than necessary.